### PR TITLE
Upgrade google pubsub gem

### DIFF
--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.license     = "MIT"
   gem.homepage    = "https://github.com/mia-0032/fluent-plugin-gcloud-pubsub-custom"
   gem.summary     = gem.description
-  gem.version     = "1.3.2"
+  gem.version     = "1.3.3"
   gem.authors     = ["Yoshihiro MIYAI"]
   gem.email       = "msparrow17@gmail.com"
   gem.files       = `git ls-files`.split("\n")
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
-  gem.add_runtime_dependency "google-cloud-pubsub", "~> 2.19.0"
+  gem.add_runtime_dependency "google-cloud-pubsub", "~> 3.1"
 
   # Use the same version constraint as fluent-plugin-prometheus currently specifies
   gem.add_runtime_dependency "prometheus-client", ">= 2.1.0"

--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.license     = "MIT"
   gem.homepage    = "https://github.com/mia-0032/fluent-plugin-gcloud-pubsub-custom"
   gem.summary     = gem.description
-  gem.version     = "1.3.3"
+  gem.version     = "1.3.4"
   gem.authors     = ["Yoshihiro MIYAI"]
   gem.email       = "msparrow17@gmail.com"
   gem.files       = `git ls-files`.split("\n")

--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency "fluentd", [">= 0.14.15", "< 2"]
-  gem.add_runtime_dependency "google-cloud-pubsub", "~> 3.1"
+  gem.add_runtime_dependency "google-cloud-pubsub", "~> 2.23"
 
   # Use the same version constraint as fluent-plugin-prometheus currently specifies
   gem.add_runtime_dependency "prometheus-client", ">= 2.1.0"

--- a/fluent-plugin-gcloud-pubsub-custom.gemspec
+++ b/fluent-plugin-gcloud-pubsub-custom.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.license     = "MIT"
   gem.homepage    = "https://github.com/mia-0032/fluent-plugin-gcloud-pubsub-custom"
   gem.summary     = gem.description
-  gem.version     = "1.3.4"
+  gem.version     = "1.3.3"
   gem.authors     = ["Yoshihiro MIYAI"]
   gem.email       = "msparrow17@gmail.com"
   gem.files       = `git ls-files`.split("\n")


### PR DESCRIPTION
Logging aggregator pods have been restarting repeatedly over the last few weeks. See [FRI-10010](https://gocardless.atlassian.net/browse/FRI-10010). The only errors we saw in the logs were messages about disconnecting from Google Pub/Sub:

```
2025-12-29 11:09:43 +0000 [error]:
unexpected error error_message="1:CANCELLED. debug_error_string:{UNKNOWN:Error received from peer
{created_time:\"2025-12-29T11:09:43.526133672+00:00\", grpc_status:1, grpc_message:\"CANCELLED\"}}"
error_class="Google::Cloud::CanceledError"
```

However, that message gets logged after a shutdown message, so it might be a symptom rather than a cause, i.e. Fluentd decides to shutdown and then disconnects from Pub/Sub.

Nevertheless, it won't hurt to try upgrading the Pub/Sub gem to the [latest release](https://rubygems.org/gems/google-cloud-pubsub/versions) in the 2.x line. This change is currently deployed and running successfully [in lab-logging](https://argocd.gocardless-lab.io/applications/lab-logging-logging-aggregator-default) via https://github.com/gocardless/logging-fluentd/pull/493.

Notes:
- I tried the latest 3.x gem but there are breaking API changes. 
- Once this is merged I will update https://github.com/gocardless/logging-fluentd/pull/493 and mark it as ready for review.

[FRI-10010]: https://gocardless.atlassian.net/browse/FRI-10010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ